### PR TITLE
Fix issues with newer scipy and Windows platforms

### DIFF
--- a/segmentation-of-nuclei/color_norm/color_normalize.py
+++ b/segmentation-of-nuclei/color_norm/color_normalize.py
@@ -1,9 +1,9 @@
-import stainNorm_Reinhard
-from scipy import misc
+from . import stainNorm_Reinhard
+from utils import imread
 
 class reinhard_normalizer():
     def __init__(self, target_file):
-        target_40X = misc.imread(target_file)
+        target_40X = imread(target_file)
         self.n_40X = stainNorm_Reinhard.Normalizer()
         self.n_40X.fit(target_40X)
 

--- a/segmentation-of-nuclei/data/nuclei_data.py
+++ b/segmentation-of-nuclei/data/nuclei_data.py
@@ -39,7 +39,7 @@ def maybe_preprocess(config, data_path, sample_path=None):
       png0_path = png_path;
       png0 = imread_rgb_image(png0_path);
       real_images.extend(png0[np.newaxis, ...]);
-      png1_path = '/'.join(png_path.split('/')[0:-1]) \
+      png1_path = '/'.join(png_path.split(os.path.sep)[0:-1]) \
               + '/image1_' + png_path.split('_')[-1];
       png1 = imread_rgb_image(png1_path);
       ref_real_images.extend(png1[np.newaxis, ...]);

--- a/segmentation-of-nuclei/data/utils.py
+++ b/segmentation-of-nuclei/data/utils.py
@@ -98,14 +98,14 @@ def save_config(model_dir, config):
     json.dump(config.__dict__, fp,  indent=4, sort_keys=True)
 
 def synthetic_to_refer_paths(paths, config):
-  return ['/'.join(x.split('/')[:-2]) + '/' + \
-          config.synthetic_refer_dir + '/' + x.split('/')[-1] for x in paths];
+  return ['/'.join(x.split(os.path.sep)[:-2]) + '/' + \
+          config.synthetic_refer_dir + '/' + x.split(os.path.sep)[-1] for x in paths];
 
 def synthetic_to_ground_truth_paths(paths, config):
-  return ['/'.join(x.split('/')[:-2]) + '/' + \
-          config.synthetic_gt_dir + '/' + x.split('/')[-1] for x in paths];
+  return ['/'.join(x.split(os.path.sep)[:-2]) + '/' + \
+          config.synthetic_gt_dir + '/' + x.split(os.path.sep)[-1] for x in paths];
 
 def supervised_to_ground_truth_paths(paths, config):
-  return ['/'.join(x.split('/')[:-2]) + '/' + \
-          config.synthetic_mask_sup_dir + '/' + x.split('/')[-1] for x in paths];
+  return ['/'.join(x.split(os.path.sep)[:-2]) + '/' + \
+          config.synthetic_mask_sup_dir + '/' + x.split(os.path.sep)[-1] for x in paths];
 

--- a/segmentation-of-nuclei/trainer.py
+++ b/segmentation-of-nuclei/trainer.py
@@ -1,13 +1,10 @@
 import os
 import numpy as np
 from tqdm import trange
-from tensorflow.contrib.framework.python.ops import arg_scope
 import scipy.stats as st
 import glob
-from scipy import misc
 from PIL import Image
 from skimage import color
-from scipy.misc import imresize
 from layers import normalize
 import sys
 import glob
@@ -18,7 +15,7 @@ from glob import iglob
 from model import Model
 from buffer import Buffer
 import data.nuclei_data as nuclei_data
-from utils import imwrite, imread, img_tile, synthetic_to_refer_paths
+from utils import imwrite, imread, imresize, img_tile, synthetic_to_refer_paths
 from preprocess import stain_normalized_tiling
 from postprocess import MultiProcWatershed
 
@@ -301,7 +298,7 @@ class Trainer(object):
               xy_indices = [];
 
         pred_m /= num_m;
-        pred_m = misc.imresize((pred_m*255).astype(np.uint8), (ori_size1, ori_size0));
+        pred_m = imresize((pred_m*255).astype(np.uint8), (ori_size1, ori_size0));
         imwrite(outf, pred_m);
         #he_outf = os.path.join(outfolder, '{}_{}_{}_{}_{}_{}_HE.png'.format(
         #                                  px, py, pw_x, pw_y, mpp, scale_factor))

--- a/segmentation-of-nuclei/utils.py
+++ b/segmentation-of-nuclei/utils.py
@@ -98,14 +98,14 @@ def save_config(model_dir, config):
     json.dump(config.__dict__, fp,  indent=4, sort_keys=True)
 
 def synthetic_to_refer_paths(paths, config):
-  return ['/'.join(x.split('/')[:-2]) + '/' + \
-          config.synthetic_refer_dir + '/' + x.split('/')[-1] for x in paths];
+  return ['/'.join(x.split(os.path.sep)[:-2]) + '/' + \
+          config.synthetic_refer_dir + '/' + x.split(os.path.sep)[-1] for x in paths];
 
 def synthetic_to_ground_truth_paths(paths, config):
-  return ['/'.join(x.split('/')[:-2]) + '/' + \
-          config.synthetic_gt_dir + '/' + x.split('/')[-1] for x in paths];
+  return ['/'.join(x.split(os.path.sep)[:-2]) + '/' + \
+          config.synthetic_gt_dir + '/' + x.split(os.path.sep)[-1] for x in paths];
 
 def supervised_to_ground_truth_paths(paths, config):
-  return ['/'.join(x.split('/')[:-2]) + '/' + \
-          config.synthetic_mask_sup_dir + '/' + x.split('/')[-1] for x in paths];
+  return ['/'.join(x.split(os.path.sep)[:-2]) + '/' + \
+          config.synthetic_mask_sup_dir + '/' + x.split(os.path.sep)[-1] for x in paths];
 

--- a/segmentation-of-nuclei/visual_seg_polygons.py
+++ b/segmentation-of-nuclei/visual_seg_polygons.py
@@ -1,4 +1,3 @@
-from scipy import misc
 from PIL import Image, ImageDraw
 import numpy as np
 import sys

--- a/training-data-synthesis/draw_mask_boundary.py
+++ b/training-data-synthesis/draw_mask_boundary.py
@@ -21,9 +21,9 @@ def canny_edge_on_mask(imgray):
 
 paths = [f for f in listdir(mask_path) if isfile(join(mask_path, f))];
 for path in paths:
-    if len(path.split('/')[-1].split('mask_')) == 1:
+    if len(path.split(os.path.sep)[-1].split('mask_')) == 1:
         continue;
-    im_no = path.split('/')[-1].split('mask_')[1].split('.png')[0];
+    im_no = path.split(os.path.sep)[-1].split('mask_')[1].split('.png')[0];
 
     mask = np.array(Image.open(join(mask_path, path)).convert('L'));
     mask_edge = canny_edge_on_mask(((mask[:,:]>0).astype(np.uint8)*255)).astype(np.float32);


### PR DESCRIPTION
Using consistently IO operations from the `utils` module, which offers a fallback to OpenCV if functions from `scipy.misc` are not available and avoids errors with newer `scipy` versions.

Also using system-dependent separator when splitting paths to avoid hard-to-debug errors on Windows platforms.
